### PR TITLE
casting/walking view tree + tests

### DIFF
--- a/firstapp/app/src/androidTest/java/com/example/firstapp/ExampleInstrumentedTest.java
+++ b/firstapp/app/src/androidTest/java/com/example/firstapp/ExampleInstrumentedTest.java
@@ -37,10 +37,6 @@ public class ExampleInstrumentedTest {
     private static String CELEBRATION = "YAYYYY! " + TARGET + "!!";
 
 
-    @Before
-    public void get_device() {
-        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
-    }
 
     @Test
     public void useAppContext() {
@@ -53,12 +49,9 @@ public class ExampleInstrumentedTest {
 
     @Test
     public void searchForTargetNumber() throws InterruptedException, IOException {
+        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
         ShellUtility.forceQuitApp(BASIC_SAMPLE_PACKAGE);
         ShellUtility.launchApp(device, BASIC_SAMPLE_PACKAGE, TIMEOUT);
-
-        //pressing count button:
-        //UiObject countButton = device.findObject(new UiSelector().className("android.widget.Button").instance(1));
-
 
         Integer val = -1;
         //Keep getting random values in the range [0, TARGET] until TARGET comes up

--- a/firstapp/app/src/androidTest/java/com/example/firstapp/MapsInstrumentedTest.java
+++ b/firstapp/app/src/androidTest/java/com/example/firstapp/MapsInstrumentedTest.java
@@ -23,7 +23,7 @@ public class MapsInstrumentedTest {
     private static final String SEARCH = "Googleplex";
 
     @Before
-    public void get_device() {
+    public void getDevice() {
         device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
     }
 
@@ -59,5 +59,7 @@ public class MapsInstrumentedTest {
         start_button.click();
 
     }
+
+
 }
 

--- a/firstapp/app/src/androidTest/java/com/example/firstapp/ShellUtility.java
+++ b/firstapp/app/src/androidTest/java/com/example/firstapp/ShellUtility.java
@@ -34,15 +34,16 @@ public class ShellUtility {
      * launched--to be used later for timing startup.
      */
     public static long launchApp(UiDevice device, String pkg, int timeoutMs) throws InterruptedException, IOException {
-        /*// Start from the home screen (might want to re-include this later)
+        /* Might want to reinclude this later:
+        //Start from the home screen
         device.pressHome();
         final String launcherPackage = device.getLauncherPackageName();
         Assert.assertThat(launcherPackage, CoreMatchers.notNullValue());
         device.wait(Until.hasObject(By.pkg(launcherPackage).depth(0)), timeoutMs);
         */
-        // Launch the app
 
-        Process process = new ProcessBuilder("am", "start", pkg).start();
+        // Launch the app
+        //Process process = new ProcessBuilder("am", "start", pkg).start();
 
 
 
@@ -76,12 +77,15 @@ public class ShellUtility {
      * views that have a textbox as a descendant and thus the view containing the text cannot be
      * clicked
      */
-    public static UiObject2 lowestClickableAncestor(UiObject2 object2) throws invalidInputException {
+    public static UiObject2 getLowestClickableAncestor(UiObject2 object2) throws invalidInputException {
         if (object2 == null) {
-            throw new invalidInputException("passed object is null. Consider increasing TIMEOUT parameter");
+            throw new invalidInputException("passed object is null. Consider increasing TIMEOUT parameter.");
         }
         while (!object2.isClickable()) {
             object2 = object2.getParent();
+        }
+        if (object2 == null) {
+            throw new invalidInputException("No clickable ancestors. Try more specific search terms.");
         }
         return object2;
     }
@@ -91,7 +95,7 @@ public class ShellUtility {
      * since UiObject2s store references to particular views and are thus worthless once that view
      * has been destroyed.
      */
-    public static UiObject castToObject(UiDevice device, UiObject2 object2) {
+    public static UiObject castToObject(UiDevice device, UiObject2 object2) throws invalidInputException {
 
         //Grab identifying information
         String resourceName = object2.getResourceName();
@@ -116,8 +120,11 @@ public class ShellUtility {
             selector = new UiSelector().description(contentDescription).className(className);
         }
 
-
-        return device.findObject(selector);
+        UiObject casted = device.findObject(selector);
+        if (casted == null) {
+            throw new invalidInputException("Casting failed. Try different actions.");
+        }
+        return casted;
     }
 
     /**
@@ -125,7 +132,7 @@ public class ShellUtility {
      * hint text in a textbox.
      */
     public static UiObject getEditableObject(UiDevice device, UiObject2 object2) throws invalidInputException {
-        return castToObject(device, lowestClickableAncestor(object2));
+        return castToObject(device, getLowestClickableAncestor(object2));
     }
 
 

--- a/firstapp/app/src/androidTest/java/com/example/firstapp/ShellUtility.java
+++ b/firstapp/app/src/androidTest/java/com/example/firstapp/ShellUtility.java
@@ -8,6 +8,7 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.uiautomator.By;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject;
+import androidx.test.uiautomator.UiObject2;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 import androidx.test.uiautomator.Until;
@@ -15,25 +16,36 @@ import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import static java.lang.Thread.sleep;
 
 
 public class ShellUtility {
+
+    public static class invalidInputException extends Exception {
+        public invalidInputException(String message) {
+            super(message);
+        }
+    }
+
     /**
      * Launches the specified App on the specified device and returns the time just before the app was
      * launched--to be used later for timing startup.
      */
-    public static long launchApp(UiDevice device, String pkg, int timeoutMs) throws InterruptedException {
-        // Start from the home screen
+    public static long launchApp(UiDevice device, String pkg, int timeoutMs) throws InterruptedException, IOException {
+        /*// Start from the home screen (might want to re-include this later)
         device.pressHome();
-
-        // Wait for launcher
         final String launcherPackage = device.getLauncherPackageName();
         Assert.assertThat(launcherPackage, CoreMatchers.notNullValue());
         device.wait(Until.hasObject(By.pkg(launcherPackage).depth(0)), timeoutMs);
-
+        */
         // Launch the app
+
+        Process process = new ProcessBuilder("am", "start", pkg).start();
+
+
+
         Context context = ApplicationProvider.getApplicationContext();
         final Intent intent = context.getPackageManager().getLaunchIntentForPackage(pkg);
 
@@ -55,7 +67,65 @@ public class ShellUtility {
 
 
     public static void forceQuitApp(String pkg) throws IOException, InterruptedException {
-        new ProcessBuilder("am", "force-stop", pkg).start();
+        Process process = new ProcessBuilder("am", "force-stop", pkg).start();
+
+    }
+
+    /**
+     * Walks up view tree until a clickable ancestor is found. Google apps often have clickable
+     * views that have a textbox as a descendant and thus the view containing the text cannot be
+     * clicked
+     */
+    public static UiObject2 lowestClickableAncestor(UiObject2 object2) throws invalidInputException {
+        if (object2 == null) {
+            throw new invalidInputException("passed object is null. Consider increasing TIMEOUT parameter");
+        }
+        while (!object2.isClickable()) {
+            object2 = object2.getParent();
+        }
+        return object2;
+    }
+
+    /**
+     * Creates a UiObject using the identifying information from a UIObject. Necessary for caching,
+     * since UiObject2s store references to particular views and are thus worthless once that view
+     * has been destroyed.
+     */
+    public static UiObject castToObject(UiDevice device, UiObject2 object2) {
+
+        //Grab identifying information
+        String resourceName = object2.getResourceName();
+        String className = object2.getClassName();
+        String text = object2.getText();
+        String contentDescription = object2.getContentDescription();
+
+        //For some reason, UiSelectors don't work properly unless fields are set during
+        // instantiation, so we consider each case separately
+        UiSelector selector = null;
+        if (resourceName != null && text != null) {
+            selector = new UiSelector().resourceId(resourceName).text(text).className(className);
+        } else if (resourceName != null && contentDescription != null) {
+            selector = new UiSelector().resourceId(resourceName).description(contentDescription).className(className);
+        } else if (contentDescription != null && text != null) {
+            selector = new UiSelector().description(contentDescription).text(text).className(className);
+        } else if (resourceName != null) {
+            selector = new UiSelector().resourceId(resourceName).className(className);
+        } else if (text != null) {
+            selector = new UiSelector().text(text).className(className);
+        } else if (contentDescription != null) {
+            selector = new UiSelector().description(contentDescription).className(className);
+        }
+
+
+        return device.findObject(selector);
+    }
+
+    /**
+     * Retrieves an editable UiObject from the UiObject2 corresponding to the view containing the
+     * hint text in a textbox.
+     */
+    public static UiObject getEditableObject(UiDevice device, UiObject2 object2) throws invalidInputException {
+        return castToObject(device, lowestClickableAncestor(object2));
     }
 
 

--- a/firstapp/app/src/androidTest/java/com/example/firstapp/ShellUtilityTest.java
+++ b/firstapp/app/src/androidTest/java/com/example/firstapp/ShellUtilityTest.java
@@ -58,8 +58,12 @@ public class ShellUtilityTest {
         UiObject2 alsoRandomButton = device.wait(Until.findObject(By.textContains("ALSO RANDOM")),TIMEOUT);
         assertEquals(false, alsoRandomButton.isClickable());
 
-        //click on the ancestor and check whether the desired action took place (previous button should be visible)
-        ShellUtility.lowestClickableAncestor(alsoRandomButton).click();
+        //click on the ancestor
+        UiObject2 clickable_button = ShellUtility.lowestClickableAncestor(alsoRandomButton);
+        assertEquals(true, clickable_button.isClickable());
+        clickable_button.click();
+
+        //check whether the desired action took place (previous button should be visible)
         UiObject2 previousButton = device.wait(Until.findObject(By.res(BASIC_SAMPLE_PACKAGE, "button_second")),TIMEOUT);
         assertNotEquals(null, previousButton);
     }

--- a/firstapp/app/src/androidTest/java/com/example/firstapp/ShellUtilityTest.java
+++ b/firstapp/app/src/androidTest/java/com/example/firstapp/ShellUtilityTest.java
@@ -2,12 +2,18 @@ package com.example.firstapp;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.uiautomator.By;
 import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObject2;
+
+import org.junit.Before;
 import org.junit.Test;
+
+import androidx.test.uiautomator.UiObjectNotFoundException;
+import androidx.test.uiautomator.UiSelector;
 import androidx.test.uiautomator.Until;
 import java.io.IOException;
 import static org.junit.Assert.*;
-
+import static java.lang.Thread.sleep;
 /**
  * Example local unit test, which will execute on the development machine (host).
  *
@@ -19,10 +25,16 @@ public class ShellUtilityTest {
     private static final int TIMEOUT = 6000;
 
 
-    @Test
-    public void launching() throws InterruptedException, IOException {
+    @Before
+    public void openingBasicApp() throws IOException, InterruptedException {
         device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+        ShellUtility.forceQuitApp(BASIC_SAMPLE_PACKAGE);
         ShellUtility.launchApp(device, BASIC_SAMPLE_PACKAGE, TIMEOUT);
+    }
+
+
+    @Test
+    public void launching() {
         Boolean appeared = device.wait(Until.hasObject(By.pkg(BASIC_SAMPLE_PACKAGE).depth(0)), TIMEOUT);
         assertEquals(true, appeared);
     }
@@ -30,10 +42,7 @@ public class ShellUtilityTest {
 
 
     @Test
-    public void quitApp() throws IOException, InterruptedException {
-        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
-        ShellUtility.forceQuitApp(BASIC_SAMPLE_PACKAGE);
-        ShellUtility.launchApp(device, BASIC_SAMPLE_PACKAGE, TIMEOUT);
+    public void quitingApp() throws IOException, InterruptedException {
         UiObject2 randomButton = device.wait(Until.findObject(By.res(BASIC_SAMPLE_PACKAGE,"random_button")), TIMEOUT);
         randomButton.click();
 
@@ -43,6 +52,43 @@ public class ShellUtilityTest {
         randomButton = device.wait(Until.findObject(By.res(BASIC_SAMPLE_PACKAGE,"random_button")), TIMEOUT);
         assertNotEquals(null, randomButton);
     }
+    @Test
+    public void gettingClickableAncestor() throws ShellUtility.invalidInputException, UiObjectNotFoundException {
+        //grab a view that is not clickable (but which has a an ancestor which is)
+        UiObject2 alsoRandomButton = device.wait(Until.findObject(By.textContains("ALSO RANDOM")),TIMEOUT);
+        assertEquals(false, alsoRandomButton.isClickable());
 
+        //click on the ancestor and check whether the desired action took place (previous button should be visible)
+        ShellUtility.lowestClickableAncestor(alsoRandomButton).click();
+        UiObject2 previousButton = device.wait(Until.findObject(By.res(BASIC_SAMPLE_PACKAGE, "button_second")),TIMEOUT);
+        assertNotEquals(null, previousButton);
+    }
+
+    @Test
+    public void casting() throws UiObjectNotFoundException {
+        UiObject2 randomButton = device.wait(Until.findObject(By.res(BASIC_SAMPLE_PACKAGE,"random_button")), TIMEOUT);
+        UiObject randomButtonCasted = ShellUtility.castToObject(device, randomButton);
+        randomButtonCasted.waitForExists(TIMEOUT);
+        randomButtonCasted.click();
+
+        //ensure that button click worked properly (previous button should be visible)
+        UiObject2 previousButton = device.wait(Until.findObject(By.res(BASIC_SAMPLE_PACKAGE, "button_second")),TIMEOUT);
+        assertNotEquals(null, previousButton);
+    }
+
+
+    @Test
+    public void gettingEditableAncestor() throws ShellUtility.invalidInputException, UiObjectNotFoundException {
+        String entered_text = "Not bad";
+        UiObject2 search_text_view= device.wait(Until.findObject(By.textContains("How does this app")),TIMEOUT);
+        UiObject clickable = ShellUtility.getEditableObject(device, search_text_view);
+        clickable.waitForExists(TIMEOUT);
+        clickable.legacySetText(entered_text);
+
+        //ensure that the textbox now displays "Not bad"
+        UiObject final_search_box = device.findObject(new UiSelector().text(entered_text));
+        final_search_box.waitForExists(TIMEOUT);
+        assertNotEquals(null, entered_text);
+    }
 
 }

--- a/firstapp/app/src/androidTest/java/com/example/firstapp/ShellUtilityTest.java
+++ b/firstapp/app/src/androidTest/java/com/example/firstapp/ShellUtilityTest.java
@@ -59,7 +59,7 @@ public class ShellUtilityTest {
         assertEquals(false, alsoRandomButton.isClickable());
 
         //click on the ancestor
-        UiObject2 clickable_button = ShellUtility.lowestClickableAncestor(alsoRandomButton);
+        UiObject2 clickable_button = ShellUtility.getLowestClickableAncestor(alsoRandomButton);
         assertEquals(true, clickable_button.isClickable());
         clickable_button.click();
 
@@ -69,7 +69,7 @@ public class ShellUtilityTest {
     }
 
     @Test
-    public void casting() throws UiObjectNotFoundException {
+    public void casting() throws UiObjectNotFoundException, ShellUtility.invalidInputException {
         UiObject2 randomButton = device.wait(Until.findObject(By.res(BASIC_SAMPLE_PACKAGE,"random_button")), TIMEOUT);
         UiObject randomButtonCasted = ShellUtility.castToObject(device, randomButton);
         randomButtonCasted.waitForExists(TIMEOUT);

--- a/firstapp/app/src/main/java/com/example/firstapp/FirstFragment.java
+++ b/firstapp/app/src/main/java/com/example/firstapp/FirstFragment.java
@@ -53,5 +53,14 @@ public class FirstFragment extends Fragment {
                 increment(view);
             }
         });
+
+        view.findViewById(R.id.deceptive_random_parent).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                int c = Integer.parseInt(countTextView.getText().toString());
+                NavDirections action = FirstFragmentDirections.actionFirstFragmentToSecondFragment(c);
+                NavHostFragment.findNavController(FirstFragment.this).navigate(action);
+            }
+        });
     }
 }

--- a/firstapp/app/src/main/res/layout/activity_main.xml
+++ b/firstapp/app/src/main/res/layout/activity_main.xml
@@ -39,4 +39,9 @@
         android:background="@color/colorAccent"
         app:popupTheme="@style/AppTheme.PopupOverlay" />
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"></LinearLayout>
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/firstapp/app/src/main/res/layout/fragment_first.xml
+++ b/firstapp/app/src/main/res/layout/fragment_first.xml
@@ -71,4 +71,31 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.479" />
+
+    <LinearLayout
+        android:id="@+id/deceptive_random_parent"
+        android:layout_width="409dp"
+        android:layout_height="197dp"
+        android:layout_marginTop="72dp"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.527"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/count_button">
+
+        <TextView
+            android:id="@+id/deceptive_random"
+            android:layout_width="match_parent"
+            android:layout_height="67dp"
+            android:ems="10"
+            android:text="ALSO RANDOM"
+            android:textAlignment="center"
+            app:layout_constraintBottom_toTopOf="@+id/textview_first"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.479" />
+
+    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
added new methods that will be necessary for caching UiObjects and ensuring that they are able to be interacted with/identifiable. Since UiObjects do not have a getParent method, UiObject2s need to be used to walk up the view tree in the scenario that a user wants to interact with an editText that contains the text they specify, but for which a textView with an editable ancestor contains the text they specify (this is seemingly the norm in Maps). Then, in order to cache information about UiObject2s in a neat manner, we "cast" them to UiObjects (since UiObject2s hold references to views, which make them useless once that view has been destroyed) by obtaining identifiable information. Anecdotally, the information we grab here is should always present in Google apps if we are careful about when we walk up the view tree (you could design an app in which this process does not work, but you'd need to have used woeful style, such as creating a button that has no text, resourceId, or content description). This way, when we use cached objects we don't need to do any searching--we simply interact with the object. These functions are designed to be robust if some changes are made to the view structure (e.g. not nesting TextViews inside of EditTexts). 

For purposing of testing, a new view has been added to the basic app's UI, which now looks like:
![Screenshot 2020-06-16 at 7 47 53 PM - Display 2](https://user-images.githubusercontent.com/42973295/84842315-67736a00-b00a-11ea-9db8-e5b98e39745c.png)
